### PR TITLE
Allow ability to use image cache

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,19 +112,6 @@ RabbitMQ HA setup
           virtual_host: '/openstack'
         ....
 
-Enable auditing filter (CADF):
-
-.. code-block:: yaml
-
-    glance:
-      server:
-        audit:
-          enabled: true
-      ....
-          filter_factory: 'keystonemiddleware.audit:filter_factory'
-          map_file: '/etc/pycadf/glance_api_audit_map.conf'
-      ....
-
 Enable Glance Image Cache:
 
 .. code-block:: yaml
@@ -136,6 +123,19 @@ Enable Glance Image Cache:
           enable_management: true
           directory: /var/lib/glance/image-cache/
           max_size: 21474836480
+      ....
+
+Enable auditing filter (CADF):
+
+.. code-block:: yaml
+
+    glance:
+      server:
+        audit:
+          enabled: true
+      ....
+          filter_factory: 'keystonemiddleware.audit:filter_factory'
+          map_file: '/etc/pycadf/glance_api_audit_map.conf'
       ....
 
 

--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,19 @@ Enable auditing filter (CADF):
           map_file: '/etc/pycadf/glance_api_audit_map.conf'
       ....
 
+Enable Glance Image Cache:
+
+.. code-block:: yaml
+
+    glance:
+      server:
+        image_cache:
+          enabled: true
+          enable_management: true
+          directory: /var/lib/glance/image-cache/
+          max_size: 21474836480
+      ....
+
 
 Client role
 -----------

--- a/glance/files/mitaka/glance-api.conf.Debian
+++ b/glance/files/mitaka/glance-api.conf.Debian
@@ -206,6 +206,7 @@ backlog = 4096
 # value)
 #key_file = <None>
 
+{% if server.get('image_cache', {}).get('enabled', False) %}
 # The path to the sqlite file database that will be used for image
 # cache management. (string value)
 #image_cache_sqlite_db = cache.db
@@ -217,15 +218,18 @@ backlog = 4096
 # beyond which the cache pruner, if running, starts cleaning the image
 # cache. (integer value)
 #image_cache_max_size = 10737418240
+image_cache_max_size = {{ server.image_cache.get('max_size', '10737418240') }}
 
 # The amount of time to let an incomplete image remain in the cache,
 # before the cache cleaner, if running, will remove the incomplete
 # image. (integer value)
 #image_cache_stall_time = 86400
+image_cache_stall_time = {{ server.image_cache.get('stall_time', '86400') }}
 
 # Base directory that the image cache uses. (string value)
 #image_cache_dir = <None>
-image_cache_dir = /var/lib/glance/image-cache/
+image_cache_dir = {{ server.image_cache.get('directory', '/var/lib/glance/image-cache/') }}
+{% endif %}
 
 # Default publisher_id for outgoing notifications. (string value)
 #default_publisher_id = image.localhost
@@ -1729,7 +1733,15 @@ rabbit_virtual_host = {{ server.message_queue.virtual_host }}
 # [pipeline:glance-api-keystone] use the value "keystone" (string
 # value)
 #flavor = <None>
+{% if server.get('image_cache', {}).get('enabled', False) %}
+{%   if server.image_cache.get('enable_management', False) %}
+flavor=keystone+cachemanagement
+{%   else %}
+flavor=keystone+caching
+{%   endif %}
+{% else %}
 flavor=keystone
+{% endif %}
 
 # Name of the paste configuration file. (string value)
 #config_file = <None>

--- a/glance/server.sls
+++ b/glance/server.sls
@@ -85,6 +85,8 @@ glance_cron_glance-cache-pruner:
   - name: glance-cache-pruner
   - user: glance
   - special: '@daily'
+  - require:
+    - service: glance_services
 
 glance_cron_glance-cache-cleaner:
   cron.present:
@@ -93,6 +95,8 @@ glance_cron_glance-cache-cleaner:
   - minute: 30
   - hour: 5
   - daymonth: '*/2'
+  - require:
+    - service: glance_services
 
 {%- endif %}
 

--- a/glance/server.sls
+++ b/glance/server.sls
@@ -79,6 +79,23 @@ glance_install_database:
   - require:
     - service: glance_services
 
+{%- if server.get('image_cache', {}).get('enabled', False) %}
+glance_cron_glance-cache-pruner:
+  cron.present:
+  - name: glance-cache-pruner
+  - user: glance
+  - special: '@daily'
+
+glance_cron_glance-cache-cleaner:
+  cron.present:
+  - name: glance-cache-cleaner
+  - user: glance
+  - minute: 30
+  - hour: 5
+  - daymonth: '*/2'
+
+{%- endif %}
+
 {%- endif %}
 
 {%- if grains.get('virtual_subtype', None) == "Docker" %}

--- a/tests/pillar/single_image_cache.sls
+++ b/tests/pillar/single_image_cache.sls
@@ -1,0 +1,41 @@
+glance:
+  server:
+    enabled: true
+    version: liberty
+    workers: 1
+    database:
+      engine: mysql
+      host: localhost
+      port: 3306
+      name: glance
+      user: glance
+      password: password
+    registry:
+      host: 127.0.0.1
+      port: 9191
+    bind:
+      address: 127.0.0.1
+      port: 9292
+    identity:
+      engine: keystone
+      host: 127.0.0.1
+      port: 35357
+      user: glance
+      password: password
+      region: RegionOne
+      tenant: service
+      endpoint_type: internalURL
+    message_queue:
+      engine: rabbitmq
+      host: 127.0.0.1
+      port: 5672
+      user: openstack
+      password: password
+      virtual_host: '/openstack'
+    storage:
+      engine: file
+    image_cache:
+      enabled: true
+      enable_management: true
+      directory: /var/lib/glance/image-cache/
+      max_size: 21474836480


### PR DESCRIPTION
For example when using swift or ceph as a backend, the image cache could improve usability for end-users. These changes are required to enable the image cache.