### PR TITLE
Adding support for (multiple) swift backends

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,30 @@ Swift integration glance
               user: 2ec7966596504f59acc3a76b3b9d9291:glance-user
               key: someRandomPassword
 
+Another way, which also supports multiple swift backends, can be configured like this:
+
+.. code-block:: yaml
+
+    glance:
+      server:
+        enabled: true
+        version: mitaka
+        storage:
+          engine: swift,http
+          swift:
+            store:
+              endpoint_type: publicURL
+              container: glance
+              create_container_on_put: true
+              retry_get_count: 5
+              references:
+                my_objectstore_reference_1:
+                  auth:
+                    address: http://keystone.example.com:5000/v2.0
+                    version: 2
+                  user: 2ec7966596504f59acc3a76b3b9d9291:glance-user
+                  key: someRandomPassword
+
 Enable CORS parameters
 
 .. code-block:: yaml

--- a/glance/files/_backends/_swift.conf
+++ b/glance/files/_backends/_swift.conf
@@ -1,0 +1,46 @@
+{%- from "glance/map.jinja" import server with context %}
+
+{% for reference_key, reference in server.storage.get('swift', {}).get('store', {}).get('references', {}).iteritems() %}
+[{{ reference_key }}]
+# A project_name user_name pair in the project_name:user_name format to authenticate against the Swift authentication service.
+user = {{ reference.user }}
+
+# An authentication key for a user authenticating against the Swift authentication service.
+key = {{ reference.key }}
+
+# An address where the Swift authentication service is located.
+auth_address = {{ reference.auth.address }}
+
+# A version of the authentication service to use. Valid versions are 2 and 3 for Keystone and 1 (deprecated) for Swauth and Rackspace.
+# Optional. Default: 2
+auth_version = {{ reference.auth.get('version', '2') }}
+
+{%- if reference.project_domain_id is defined %}
+# A domain ID of the project which is the requested project-level authorization scope.
+# Optional. Default: None
+# This option can be specified if ``auth_version` is 3 .`
+project_domain_id = {{ reference.project_domain_id }}
+{% endif %}
+
+{%- if reference.project_domain_name is defined %}
+# A domain name of the project which is the requested project-level authorization scope.
+# Optional. Default: None
+# This option can be specified if ``auth_version` is 3 .`
+project_domain_name = {{ reference.project_domain_name }}
+{% endif %}
+
+{%- if reference.user_domain_id is defined %}
+# A domain ID of the user which is the requested domain-level authorization scope.
+# Optional. Default: None
+# This option can be specified if ``auth_version` is 3 .`
+user_domain_id = {{ reference.user_domain_id }}
+{% endif %}
+
+{%- if reference.user_domain_name is defined %}
+# A domain name of the user which is the requested domain-level authorization scope.
+# Optional. Default: None
+# This option can be specified if ``auth_version` is 3. `
+user_domain_name = {{ reference.user_domain_name }}
+{% endif %}
+
+{% endfor %}

--- a/glance/files/mitaka/glance-api.conf.Debian
+++ b/glance/files/mitaka/glance-api.conf.Debian
@@ -828,7 +828,7 @@ stores = {{ server.storage.engine }}
 # If True, swiftclient won't check for a valid SSL certificate when
 # authenticating. (boolean value)
 #swift_store_auth_insecure = false
-swift_store_auth_insecure = {{ server.storage.swift.store.auth.get('insecure', False)|lower }}
+swift_store_auth_insecure = {{ server.storage.swift.store.get('auth', {}).get('insecure', False)|lower }}
 
 # A string giving the CA certificate file to use in SSL connections
 # for verifying certs. (string value)
@@ -962,32 +962,40 @@ default_swift_reference = {{ server.storage.swift.store.default_swift_reference 
 # (deprecated - use "auth_version" in swift_store_config_file) (string
 # value)
 #swift_store_auth_version = 2
+{% if server.storage.swift.store.get('auth', {}).get('version', False) %}
 swift_store_auth_version = {{ server.storage.swift.store.auth.version }}
+{% endif %}
 
 # The address where the Swift authentication service is listening.
 # (deprecated - use "auth_address" in swift_store_config_file) (string
 # value)
 #swift_store_auth_address = <None>
+{% if server.storage.swift.store.get('auth', {}).get('address', False) %}
 swift_store_auth_address = {{ server.storage.swift.store.auth.address }}
+{% endif %}
 
 # The user to authenticate against the Swift authentication service
 # (deprecated - use "user" in swift_store_config_file) (string value)
 #swift_store_user = <None>
+{% if server.storage.swift.store.user is defined %}
 swift_store_user = {{ server.storage.swift.store.user }}
+{% endif %}
 
 # Auth key for the user authenticating against the Swift
 # authentication service. (deprecated - use "key" in
 # swift_store_config_file) (string value)
 #swift_store_key = <None>
+{% if server.storage.swift.store.key is defined %}
 swift_store_key = {{ server.storage.swift.store.key }}
+{% endif %}
 
 # The config file that has the swift account(s)configs. (string value)
 #swift_store_config_file = <None>
-{% if server.storage.swift.store.config_file is defined %}
-swift_store_config_file = {{ server.storage.swift.store.config_file }}
+{% if server.storage.swift.store.references is defined %}
+swift_store_config_file = /etc/glance/swift-stores.conf
+{% endif %}
 {% endif %}
 
-{% endif %}
 
 {%- if 'rbd' in storage_engines %}
 # RADOS images will be chunked into objects of this size (in

--- a/glance/files/newton/glance-api.conf.Debian
+++ b/glance/files/newton/glance-api.conf.Debian
@@ -2604,7 +2604,7 @@ rbd_store_ceph_conf = /etc/ceph/ceph.conf
 #  (boolean value)
 {%- if 'swift' in storage_engines %}
 #swift_store_auth_insecure = false
-swift_store_auth_insecure = {{ server.storage.swift.store.auth.get('insecure', False)|lower }}
+swift_store_auth_insecure = {{ server.storage.swift.store.get('auth', {}).get('insecure', False)|lower }}
 
 #
 # Path to the CA bundle file.
@@ -3052,7 +3052,9 @@ default_swift_reference = {{ server.storage.swift.store.default_swift_reference 
 # The option 'auth_version' in the Swift back-end configuration file is
 # used instead.
 #swift_store_auth_version = 2
+{% if server.storage.swift.store.get('auth', {}).get('version', False) %}
 swift_store_auth_version = {{ server.storage.swift.store.auth.version }}
+{% endif %}
 
 # DEPRECATED: The address where the Swift authentication service is listening.
 # (string value)
@@ -3062,7 +3064,9 @@ swift_store_auth_version = {{ server.storage.swift.store.auth.version }}
 # The option 'auth_address' in the Swift back-end configuration file is
 # used instead.
 #swift_store_auth_address = <None>
+{% if server.storage.swift.store.get('auth', {}).get('address', False) %}
 swift_store_auth_address = {{ server.storage.swift.store.auth.address }}
+{% endif %}
 
 # DEPRECATED: The user to authenticate against the Swift authentication service.
 # (string value)
@@ -3071,7 +3075,9 @@ swift_store_auth_address = {{ server.storage.swift.store.auth.address }}
 # Reason:
 # The option 'user' in the Swift back-end configuration file is set instead.
 #swift_store_user = <None>
+{% if server.storage.swift.store.user is defined %}
 swift_store_user = {{ server.storage.swift.store.user }}
+{% endif %}
 
 # DEPRECATED: Auth key for the user authenticating against the Swift
 # authentication service. (string value)
@@ -3081,7 +3087,9 @@ swift_store_user = {{ server.storage.swift.store.user }}
 # The option 'key' in the Swift back-end configuration file is used
 # to set the authentication key instead.
 #swift_store_key = <None>
+{% if server.storage.swift.store.key is defined %}
 swift_store_key = {{ server.storage.swift.store.key }}
+{% endif %}
 
 #
 # Absolute path to the file containing the swift account(s)
@@ -3103,8 +3111,8 @@ swift_store_key = {{ server.storage.swift.store.key }}
 #
 #  (string value)
 #swift_store_config_file = <None>
-{% if server.storage.swift.store.config_file is defined %}
-swift_store_config_file = {{ server.storage.swift.store.config_file }}
+{% if server.storage.swift.store.references is defined %}
+swift_store_config_file = /etc/glance/swift-stores.conf
 {% endif %}
 
 {% endif %}

--- a/glance/files/ocata/glance-api.conf.Debian
+++ b/glance/files/ocata/glance-api.conf.Debian
@@ -2670,7 +2670,7 @@ rbd_store_ceph_conf = /etc/ceph/ceph.conf
 #  (boolean value)
 {%- if 'swift' in storage_engines %}
 #swift_store_auth_insecure = false
-swift_store_auth_insecure = {{ server.storage.swift.store.auth.get('insecure', False)|lower }}
+swift_store_auth_insecure = {{ server.storage.swift.store.get('auth', {}).get('insecure', False)|lower }}
 
 #
 # Path to the CA bundle file.
@@ -3118,7 +3118,9 @@ default_swift_reference = {{ server.storage.swift.store.default_swift_reference 
 # The option 'auth_version' in the Swift back-end configuration file is
 # used instead.
 #swift_store_auth_version = 2
+{% if server.storage.swift.store.get('auth', {}).get('version', False) %}
 swift_store_auth_version = {{ server.storage.swift.store.auth.version }}
+{% endif %}
 
 # DEPRECATED: The address where the Swift authentication service is listening.
 # (string value)
@@ -3128,7 +3130,9 @@ swift_store_auth_version = {{ server.storage.swift.store.auth.version }}
 # The option 'auth_address' in the Swift back-end configuration file is
 # used instead.
 #swift_store_auth_address = <None>
+{% if server.storage.swift.store.get('auth', {}).get('address', False) %}
 swift_store_auth_address = {{ server.storage.swift.store.auth.address }}
+{% endif %}
 
 # DEPRECATED: The user to authenticate against the Swift authentication service.
 # (string value)
@@ -3137,7 +3141,9 @@ swift_store_auth_address = {{ server.storage.swift.store.auth.address }}
 # Reason:
 # The option 'user' in the Swift back-end configuration file is set instead.
 #swift_store_user = <None>
+{% if server.storage.swift.store.user is defined %}
 swift_store_user = {{ server.storage.swift.store.user }}
+{% endif %}
 
 # DEPRECATED: Auth key for the user authenticating against the Swift
 # authentication service. (string value)
@@ -3147,7 +3153,9 @@ swift_store_user = {{ server.storage.swift.store.user }}
 # The option 'key' in the Swift back-end configuration file is used
 # to set the authentication key instead.
 #swift_store_key = <None>
+{% if server.storage.swift.store.key is defined %}
 swift_store_key = {{ server.storage.swift.store.key }}
+{% endif %}
 
 #
 # Absolute path to the file containing the swift account(s)
@@ -3169,8 +3177,8 @@ swift_store_key = {{ server.storage.swift.store.key }}
 #
 #  (string value)
 #swift_store_config_file = <None>
-{% if server.storage.swift.store.config_file is defined %}
-swift_store_config_file = {{ server.storage.swift.store.config_file }}
+{% if server.storage.swift.store.references is defined %}
+swift_store_config_file = /etc/glance/swift-stores.conf
 {% endif %}
 
 {% endif %}

--- a/glance/server.sls
+++ b/glance/server.sls
@@ -98,6 +98,17 @@ glance_glare_service:
 {%- endif %}
 {%- endif %}
 
+{% if server.storage.get('swift', {}).get('store', {}).get('references', {}) %}
+/etc/glance/swift-stores.conf:
+  file.managed:
+  - source: salt://glance/files/_backends/_swift.conf
+  - template: jinja
+  - require:
+    - pkg: glance_packages
+  - watch_in:
+    - service: glance_services
+{% endif %}
+
 {%- if not grains.get('noservices', False) %}
 
 glance_services:

--- a/tests/pillar/single_swift.sls
+++ b/tests/pillar/single_swift.sls
@@ -1,7 +1,7 @@
 glance:
   server:
     enabled: true
-    version: liberty
+    version: mitaka
     workers: 1
     database:
       engine: mysql

--- a/tests/pillar/single_swift_references.sls
+++ b/tests/pillar/single_swift_references.sls
@@ -1,7 +1,7 @@
 glance:
   server:
     enabled: true
-    version: liberty
+    version: mitaka
     workers: 1
     database:
       engine: mysql

--- a/tests/pillar/single_swift_references.sls
+++ b/tests/pillar/single_swift_references.sls
@@ -1,0 +1,69 @@
+glance:
+  server:
+    enabled: true
+    version: liberty
+    workers: 1
+    database:
+      engine: mysql
+      host: localhost
+      port: 3306
+      name: glance
+      user: glance
+      password: password
+    registry:
+      host: 127.0.0.1
+      port: 9191
+    bind:
+      address: 127.0.0.1
+      port: 9292
+    identity:
+      engine: keystone
+      host: 127.0.0.1
+      port: 35357
+      user: glance
+      password: password
+      region: RegionOne
+      tenant: service
+      endpoint_type: internalURL
+    message_queue:
+      engine: rabbitmq
+      host: 127.0.0.1
+      port: 5672
+      user: openstack
+      password: password
+      virtual_host: '/openstack'
+    storage:
+      engine: swift
+      swift:
+        store:
+          # admin_tenants: 
+          cacert: /etc/ssl/certs/ca-certificates.crt
+          # config_file: 
+          container: glance
+          create_container_on_put: true
+          endpoint: swift
+          endpoint_type: internalURL
+          expire_soon_interval: 60
+          large_object_size: 5120
+          large_object_chunk_size: 200
+          multi_tenant: false
+          multiple_containers_seed: 0
+          retry_get_count: 5
+          region: RegionOne
+          service_type: object-store
+          ssl_compression: false
+          use_trusts: false
+          default_swift_reference: my_swift_server
+          references:
+            my_swift_server:
+              auth:
+                address: http://127.0.0.1:5000/v2.0
+                version: 2
+              user: 2ec7966596504f59acc3a76b3b9d9291:glance-user
+              key: someRandomPassword
+            my_second_swift_server:
+              auth:
+                address: http://127.0.0.2:5000/v2.0
+                version: 2
+              user: 2ec7966596504f59acc3a76b3b9d9291:glance-user
+              key: someRandomPassword


### PR DESCRIPTION
Add support for swift_store_config_file setting and generating the references based on pillar data.