### PR TITLE
Allow file engine to be used with other engines

### DIFF
--- a/glance/files/mitaka/glance-api.conf.Debian
+++ b/glance/files/mitaka/glance-api.conf.Debian
@@ -792,7 +792,7 @@ max_overflow = 30
 # List of stores enabled. Valid stores are: cinder, file, http, rbd,
 # sheepdog, swift, s3, vsphere (list value)
 #stores = file,http
-{%- if 'file' in storage_engines %}
+{%- if ['file'] == storage_engines %}
 default_store = file
 stores = file,http
 {%- else %}

--- a/glance/files/newton/glance-api.conf.Debian
+++ b/glance/files/newton/glance-api.conf.Debian
@@ -1929,7 +1929,7 @@ max_overflow = 30
 #
 #  (list value)
 #stores = file,http
-{%- if 'file' in storage_engines %}
+{%- if ['file'] == storage_engines %}
 default_store = file
 stores = file,http
 {%- else %}

--- a/glance/files/ocata/glance-api.conf.Debian
+++ b/glance/files/ocata/glance-api.conf.Debian
@@ -1995,7 +1995,7 @@ max_overflow = 30
 #
 #  (list value)
 #stores = file,http
-{%- if 'file' in storage_engines %}
+{%- if ['file'] == storage_engines %}
 default_store = file
 stores = file,http
 {%- else %}


### PR DESCRIPTION
A cloud should be allowed to enable file and rbd or swift backends.
This check prevented other backends from being enabled if file was in
the list.