### PR TITLE
Allow enabling or disabling v1 and v2 APIs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -209,6 +209,17 @@ Enable CORS parameters
           allow_credentials: True
           max_age: 86400
 
+Enable/disable diffent API versions
+
+.. code-block:: yaml
+
+    glance:
+      server:
+        enable_v1_api: False
+        enable_v1_registry: False
+        enable_v2_api: True
+        enable_v2_registry: True
+
 Enable Viewing Multiple Locations
 ---------------------------------
 If you want to expose all locations available (for example when you have

--- a/glance/files/mitaka/glance-api.conf.Debian
+++ b/glance/files/mitaka/glance-api.conf.Debian
@@ -94,15 +94,19 @@ show_multiple_locations = {{ server.get('show_multiple_locations', False) | lowe
 
 # Deploy the v1 OpenStack Images API. (boolean value)
 #enable_v1_api = true
+enable_v1_api = {{ server.get('enable_v1_api', True) }}
 
 # Deploy the v2 OpenStack Images API. (boolean value)
 #enable_v2_api = true
+enable_v2_api = {{ server.get('enable_v2_api', True) }}
 
 # Deploy the v1 OpenStack Registry API. (boolean value)
 #enable_v1_registry = true
+enable_v1_registry = {{ server.get('enable_v1_registry', server.get('enable_v1_api', True)) }}
 
 # Deploy the v2 OpenStack Registry API. (boolean value)
 #enable_v2_registry = true
+enable_v2_registry = {{ server.get('enable_v2_registry', True) }}
 
 # The hostname/IP of the pydev process listening for debug connections
 # (string value)

--- a/glance/files/newton/glance-api.conf.Debian
+++ b/glance/files/newton/glance-api.conf.Debian
@@ -415,7 +415,7 @@ show_multiple_locations = {{ server.get('show_multiple_locations', False) | lowe
 #
 #  (boolean value)
 #enable_v1_api = true
-enable_v1_api=False
+enable_v1_api = {{ server.get('enable_v1_api', False) }}
 
 #
 # Deploy the v2 OpenStack Images API.
@@ -446,7 +446,7 @@ enable_v1_api=False
 #
 #  (boolean value)
 #enable_v2_api = true
-enable_v2_api=True
+enable_v2_api = {{ server.get('enable_v2_api', True) }}
 
 #
 # Deploy the v1 API Registry service.
@@ -470,6 +470,7 @@ enable_v2_api=True
 #
 #  (boolean value)
 #enable_v1_registry = true
+enable_v1_registry = {{ server.get('enable_v1_registry', server.get('enable_v1_api', False)) }}
 
 #
 # Deploy the v2 API Registry service.
@@ -496,6 +497,7 @@ enable_v2_api=True
 #
 #  (boolean value)
 #enable_v2_registry = true
+enable_v2_registry = {{ server.get('enable_v2_registry', True) }}
 
 #
 # Host address of the pydev server.

--- a/glance/files/ocata/glance-api.conf.Debian
+++ b/glance/files/ocata/glance-api.conf.Debian
@@ -415,7 +415,7 @@ show_multiple_locations = {{ server.get('show_multiple_locations', False) | lowe
 #
 #  (boolean value)
 #enable_v1_api = true
-enable_v1_api=False
+enable_v1_api = {{ server.get('enable_v1_api', False) }}
 
 #
 # Deploy the v2 OpenStack Images API.
@@ -446,7 +446,7 @@ enable_v1_api=False
 #
 #  (boolean value)
 #enable_v2_api = true
-enable_v2_api=True
+enable_v2_api = {{ server.get('enable_v2_api', True) }}
 
 #
 # Deploy the v1 API Registry service.
@@ -470,6 +470,7 @@ enable_v2_api=True
 #
 #  (boolean value)
 #enable_v1_registry = true
+enable_v1_registry = {{ server.get('enable_v1_registry', server.get('enable_v1_api', False)) }}
 
 #
 # Deploy the v2 API Registry service.
@@ -496,6 +497,7 @@ enable_v2_api=True
 #
 #  (boolean value)
 #enable_v2_registry = true
+enable_v2_registry = {{ server.get('enable_v2_registry', True) }}
 
 #
 # Host address of the pydev server.


### PR DESCRIPTION
Some deployments may have clients or services that depend on the v1
Glance API version; For example ironic in newton.  Add configuration
settings that allow users to override the availability of the v1 or v2
APIs and Registries.