### PR TITLE
Enable Tasks API for image conversion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -209,6 +209,19 @@ Enable CORS parameters
           allow_credentials: True
           max_age: 86400
 
+Enable Tasks API for automatic image conversion.
+
+.. code-block:: yaml
+
+    glance:
+      server:
+        storage:
+          engine: rbd,file,http
+        tasks:
+          enabled: True
+          work_dir: /var/lib/glance/import
+          conversion_format: raw
+
 Enable Viewing Multiple Locations
 ---------------------------------
 If you want to expose all locations available (for example when you have

--- a/glance/files/mitaka/glance-api.conf.Debian
+++ b/glance/files/mitaka/glance-api.conf.Debian
@@ -1866,6 +1866,7 @@ store_type_preference = {{ server.store_type_preference }}
 {% endif %}
 
 
+{% if server.get('tasks', {}).get('enabled', False) %}
 [task]
 
 #
@@ -1896,6 +1897,7 @@ store_type_preference = {{ server.store_type_preference }}
 # estimations and you should do them based on the worst case scenario
 # and be prepared to act in case they were wrong. (string value)
 #work_dir = <None>
+work_dir= {{ server.tasks.get('work_dir', '/var/lib/glance/import') }}
 
 
 [taskflow_executor]
@@ -1914,3 +1916,39 @@ store_type_preference = {{ server.store_type_preference }}
 # 'parallel'. (integer value)
 # Deprecated group/name - [task]/eventlet_executor_pool_size
 #max_workers = 10
+#
+
+# Set the desired image conversion format.
+#
+# Provide a valid image format to which you want images to be
+# converted before they are stored for consumption by Glance.
+# Appropriate image format conversions are desirable for specific
+# storage backends in order to facilitate efficient handling of
+# bandwidth and usage of the storage infrastructure.
+#
+# By default, ``conversion_format`` is not set and must be set
+# explicitly in the configuration file.
+#
+# The allowed values for this option are ``raw``, ``qcow2`` and
+# ``vmdk``. The  ``raw`` format is the unstructured disk format and
+# should be chosen when RBD or Ceph storage backends are used for
+# image storage. ``qcow2`` is supported by the QEMU emulator that
+# expands dynamically and supports Copy on Write. The ``vmdk`` is
+# another common disk format supported by many common virtual machine
+# monitors like VMWare Workstation.
+#
+# Possible values:
+#     * qcow2
+#     * raw
+#     * vmdk
+#
+# Related options:
+#     * disk_formats
+#
+#  (string value)
+# Allowed values: qcow2, raw, vmdk
+{% if server.tasks.conversion_format is defined %}
+conversion_format = {{ server.tasks.conversion_format }}
+{% endif %}
+
+{% endif %}

--- a/glance/files/newton/glance-api.conf.Debian
+++ b/glance/files/newton/glance-api.conf.Debian
@@ -4350,6 +4350,9 @@ store_type_preference = {{ server.store_type_preference }}
 #
 #  (string value)
 #work_dir = /work_dir
+{% if server.get('tasks', {}).get('enabled', False) %}
+work_dir= {{ server.tasks.get('work_dir', '/var/lib/glance/import') }}
+{% endif %}
 
 
 [taskflow_executor]
@@ -4431,4 +4434,8 @@ store_type_preference = {{ server.store_type_preference }}
 #
 #  (string value)
 # Allowed values: qcow2, raw, vmdk
-#conversion_format = raw
+{% if server.get('tasks', {}).get('enabled', False) %}
+{% if server.tasks.conversion_format is defined %}
+conversion_format = {{ server.tasks.conversion_format }}
+{% endif %}
+{% endif %}

--- a/glance/files/ocata/glance-api.conf.Debian
+++ b/glance/files/ocata/glance-api.conf.Debian
@@ -4416,6 +4416,9 @@ store_type_preference = {{ server.store_type_preference }}
 #
 #  (string value)
 #work_dir = /work_dir
+{% if server.get('tasks', {}).get('enabled', False) %}
+work_dir= {{ server.tasks.get('work_dir', '/var/lib/glance/import') }}
+{% endif %}
 
 
 [taskflow_executor]
@@ -4497,4 +4500,8 @@ store_type_preference = {{ server.store_type_preference }}
 #
 #  (string value)
 # Allowed values: qcow2, raw, vmdk
-#conversion_format = raw
+{% if server.get('tasks', {}).get('enabled', False) %}
+{% if server.tasks.conversion_format is defined %}
+conversion_format = {{ server.tasks.conversion_format }}
+{% endif %}
+{% endif %}

--- a/glance/server.sls
+++ b/glance/server.sls
@@ -241,4 +241,15 @@ rule_{{ name }}_absent:
 
 {%- endfor %}
 
+{%- if server.get('tasks', {}).get('enabled', False) %}
+glance_task_direcotry:
+  file.directory:
+  - name: {{ server.tasks.get('work_dir', '/var/lib/glance/import') }}
+  - mode: 755
+  - user: glance
+  - group: glance
+  - require:
+    - pkg: glance_packages
+{%- endif %}
+
 {%- endif %}


### PR DESCRIPTION
conversion_format must explicitly be set in the config file.
work_dir must explicitly be set in the config file.