### PR TITLE
Allow enabling the v1 api (though it is deprecated)

### DIFF
--- a/glance/files/ocata/glance-api.conf.Debian
+++ b/glance/files/ocata/glance-api.conf.Debian
@@ -440,7 +440,7 @@ user_storage_quota = {{ server.quota.user_storage|default('0') }}
 #
 #  (boolean value)
 #enable_v1_api = true
-enable_v1_api=False
+enable_v1_api={{ server.get('enable_v1_api', 'False')|lower }}
 
 #
 # Deploy the v2 OpenStack Images API.

--- a/glance/files/ocata/glance-registry.conf.Debian
+++ b/glance/files/ocata/glance-registry.conf.Debian
@@ -391,6 +391,7 @@ api_limit_max = 1000
 #
 #  (boolean value)
 #enable_v1_api = true
+enable_v1_api={{ server.get('enable_v1_api', 'False')|lower }}
 
 #
 # Deploy the v2 OpenStack Images API.
@@ -444,6 +445,7 @@ api_limit_max = 1000
 #
 #  (boolean value)
 #enable_v1_registry = true
+enable_v1_registry={{ server.get('enable_v1_api', 'False')|lower }}
 
 #
 # Deploy the v2 API Registry service.


### PR DESCRIPTION
We (and customers probably too) have tooling in place that still use the v1 api, therefore we need this api enabled.