### PR TITLE
Adding conditional processing of swift auth parameters

### DIFF
--- a/glance/files/newton/glance-glare.conf.Debian
+++ b/glance/files/newton/glance-glare.conf.Debian
@@ -1361,7 +1361,9 @@ rbd_store_ceph_conf = /etc/ceph/ceph.conf
 
 {%- if 'swift' in storage_engines %}
 #swift_store_auth_insecure = false
+{% if server.storage.swift.store.get('auth', {}).get('insecure', False) %}
 swift_store_auth_insecure = {{ server.storage.swift.store.auth.get('insecure', False)|lower }}
+{% endif %}
 
 #
 # Path to the CA bundle file.
@@ -1809,7 +1811,10 @@ default_swift_reference = {{ server.storage.swift.store.default_swift_reference 
 # The option 'auth_version' in the Swift back-end configuration file is
 # used instead.
 #swift_store_auth_version = 2
+
+{% if server.storage.swift.store.get('auth', {}).get('version', False) %}
 swift_store_auth_version = {{ server.storage.swift.store.auth.version }}
+{% endif %}
 
 # DEPRECATED: The address where the Swift authentication service is listening.
 # (string value)
@@ -1819,7 +1824,10 @@ swift_store_auth_version = {{ server.storage.swift.store.auth.version }}
 # The option 'auth_address' in the Swift back-end configuration file is
 # used instead.
 #swift_store_auth_address = <None>
+
+{% if server.storage.swift.store.get('auth', {}).get('address', False) %}
 swift_store_auth_address = {{ server.storage.swift.store.auth.address }}
+{% endif %}
 
 # DEPRECATED: The user to authenticate against the Swift authentication service.
 # (string value)
@@ -1828,7 +1836,9 @@ swift_store_auth_address = {{ server.storage.swift.store.auth.address }}
 # Reason:
 # The option 'user' in the Swift back-end configuration file is set instead.
 #swift_store_user = <None>
+{% if server.storage.swift.store.get('user', False) %}
 swift_store_user = {{ server.storage.swift.store.user }}
+{% endif %}
 
 # DEPRECATED: Auth key for the user authenticating against the Swift
 # authentication service. (string value)
@@ -1838,7 +1848,9 @@ swift_store_user = {{ server.storage.swift.store.user }}
 # The option 'key' in the Swift back-end configuration file is used
 # to set the authentication key instead.
 #swift_store_key = <None>
+{% if server.storage.swift.store.get('key', False) %}
 swift_store_key = {{ server.storage.swift.store.key }}
+{% endif %}
 
 #
 # Absolute path to the file containing the swift account(s)
@@ -1860,8 +1872,8 @@ swift_store_key = {{ server.storage.swift.store.key }}
 #
 #  (string value)
 #swift_store_config_file = <None>
-{% if server.storage.swift.store.config_file is defined %}
-swift_store_config_file = {{ server.storage.swift.store.config_file }}
+{% if server.storage.swift.store.references is defined %}
+swift_store_config_file = /etc/glance/swift-stores.conf
 {% endif %}
 
 {% endif %}

--- a/glance/files/newton/glance-glare.conf.Debian
+++ b/glance/files/newton/glance-glare.conf.Debian
@@ -1361,7 +1361,7 @@ rbd_store_ceph_conf = /etc/ceph/ceph.conf
 
 {%- if 'swift' in storage_engines %}
 #swift_store_auth_insecure = false
-{% if server.storage.swift.store.get('auth', {}).get('insecure', False) %}
+{%- if server.storage.swift.store.get('auth', {}).get('insecure', False) %}
 swift_store_auth_insecure = {{ server.storage.swift.store.auth.get('insecure', False)|lower }}
 {% endif %}
 
@@ -1811,8 +1811,7 @@ default_swift_reference = {{ server.storage.swift.store.default_swift_reference 
 # The option 'auth_version' in the Swift back-end configuration file is
 # used instead.
 #swift_store_auth_version = 2
-
-{% if server.storage.swift.store.get('auth', {}).get('version', False) %}
+{%- if server.storage.swift.store.get('auth', {}).get('version', False) %}
 swift_store_auth_version = {{ server.storage.swift.store.auth.version }}
 {% endif %}
 
@@ -1824,8 +1823,7 @@ swift_store_auth_version = {{ server.storage.swift.store.auth.version }}
 # The option 'auth_address' in the Swift back-end configuration file is
 # used instead.
 #swift_store_auth_address = <None>
-
-{% if server.storage.swift.store.get('auth', {}).get('address', False) %}
+{%- if server.storage.swift.store.get('auth', {}).get('address', False) %}
 swift_store_auth_address = {{ server.storage.swift.store.auth.address }}
 {% endif %}
 
@@ -1836,7 +1834,7 @@ swift_store_auth_address = {{ server.storage.swift.store.auth.address }}
 # Reason:
 # The option 'user' in the Swift back-end configuration file is set instead.
 #swift_store_user = <None>
-{% if server.storage.swift.store.get('user', False) %}
+{%- if server.storage.swift.store.get('user', False) %}
 swift_store_user = {{ server.storage.swift.store.user }}
 {% endif %}
 
@@ -1848,7 +1846,7 @@ swift_store_user = {{ server.storage.swift.store.user }}
 # The option 'key' in the Swift back-end configuration file is used
 # to set the authentication key instead.
 #swift_store_key = <None>
-{% if server.storage.swift.store.get('key', False) %}
+{%- if server.storage.swift.store.get('key', False) %}
 swift_store_key = {{ server.storage.swift.store.key }}
 {% endif %}
 

--- a/glance/files/ocata/glance-glare.conf.Debian
+++ b/glance/files/ocata/glance-glare.conf.Debian
@@ -1363,7 +1363,9 @@ rbd_store_ceph_conf = /etc/ceph/ceph.conf
 
 {%- if 'swift' in storage_engines %}
 #swift_store_auth_insecure = false
+{% if server.storage.swift.store.get('auth', {}).get('insecure', False) %}
 swift_store_auth_insecure = {{ server.storage.swift.store.auth.get('insecure', False)|lower }}
+{% endif %}
 
 #
 # Path to the CA bundle file.
@@ -1811,7 +1813,10 @@ default_swift_reference = {{ server.storage.swift.store.default_swift_reference 
 # The option 'auth_version' in the Swift back-end configuration file is
 # used instead.
 #swift_store_auth_version = 2
+
+{% if server.storage.swift.store.get('auth', {}).get('version', False) %}
 swift_store_auth_version = {{ server.storage.swift.store.auth.version }}
+{% endif %}
 
 # DEPRECATED: The address where the Swift authentication service is listening.
 # (string value)
@@ -1821,7 +1826,10 @@ swift_store_auth_version = {{ server.storage.swift.store.auth.version }}
 # The option 'auth_address' in the Swift back-end configuration file is
 # used instead.
 #swift_store_auth_address = <None>
+
+{% if server.storage.swift.store.get('auth', {}).get('address', False) %}
 swift_store_auth_address = {{ server.storage.swift.store.auth.address }}
+{% endif %}
 
 # DEPRECATED: The user to authenticate against the Swift authentication service.
 # (string value)
@@ -1830,7 +1838,9 @@ swift_store_auth_address = {{ server.storage.swift.store.auth.address }}
 # Reason:
 # The option 'user' in the Swift back-end configuration file is set instead.
 #swift_store_user = <None>
+{% if server.storage.swift.store.get('user', False) %}
 swift_store_user = {{ server.storage.swift.store.user }}
+{% endif %}
 
 # DEPRECATED: Auth key for the user authenticating against the Swift
 # authentication service. (string value)
@@ -1840,7 +1850,9 @@ swift_store_user = {{ server.storage.swift.store.user }}
 # The option 'key' in the Swift back-end configuration file is used
 # to set the authentication key instead.
 #swift_store_key = <None>
+{% if server.storage.swift.store.get('key', False) %}
 swift_store_key = {{ server.storage.swift.store.key }}
+{% endif %}
 
 #
 # Absolute path to the file containing the swift account(s)
@@ -1862,8 +1874,8 @@ swift_store_key = {{ server.storage.swift.store.key }}
 #
 #  (string value)
 #swift_store_config_file = <None>
-{% if server.storage.swift.store.config_file is defined %}
-swift_store_config_file = {{ server.storage.swift.store.config_file }}
+{% if server.storage.swift.store.references is defined %}
+swift_store_config_file = /etc/glance/swift-stores.conf
 {% endif %}
 
 {% endif %}

--- a/glance/files/ocata/glance-glare.conf.Debian
+++ b/glance/files/ocata/glance-glare.conf.Debian
@@ -1363,7 +1363,7 @@ rbd_store_ceph_conf = /etc/ceph/ceph.conf
 
 {%- if 'swift' in storage_engines %}
 #swift_store_auth_insecure = false
-{% if server.storage.swift.store.get('auth', {}).get('insecure', False) %}
+{%- if server.storage.swift.store.get('auth', {}).get('insecure', False) %}
 swift_store_auth_insecure = {{ server.storage.swift.store.auth.get('insecure', False)|lower }}
 {% endif %}
 
@@ -1813,8 +1813,7 @@ default_swift_reference = {{ server.storage.swift.store.default_swift_reference 
 # The option 'auth_version' in the Swift back-end configuration file is
 # used instead.
 #swift_store_auth_version = 2
-
-{% if server.storage.swift.store.get('auth', {}).get('version', False) %}
+{%- if server.storage.swift.store.get('auth', {}).get('version', False) %}
 swift_store_auth_version = {{ server.storage.swift.store.auth.version }}
 {% endif %}
 
@@ -1826,8 +1825,7 @@ swift_store_auth_version = {{ server.storage.swift.store.auth.version }}
 # The option 'auth_address' in the Swift back-end configuration file is
 # used instead.
 #swift_store_auth_address = <None>
-
-{% if server.storage.swift.store.get('auth', {}).get('address', False) %}
+{%- if server.storage.swift.store.get('auth', {}).get('address', False) %}
 swift_store_auth_address = {{ server.storage.swift.store.auth.address }}
 {% endif %}
 
@@ -1838,7 +1836,7 @@ swift_store_auth_address = {{ server.storage.swift.store.auth.address }}
 # Reason:
 # The option 'user' in the Swift back-end configuration file is set instead.
 #swift_store_user = <None>
-{% if server.storage.swift.store.get('user', False) %}
+{%- if server.storage.swift.store.get('user', False) %}
 swift_store_user = {{ server.storage.swift.store.user }}
 {% endif %}
 
@@ -1850,7 +1848,7 @@ swift_store_user = {{ server.storage.swift.store.user }}
 # The option 'key' in the Swift back-end configuration file is used
 # to set the authentication key instead.
 #swift_store_key = <None>
-{% if server.storage.swift.store.get('key', False) %}
+{%- if server.storage.swift.store.get('key', False) %}
 swift_store_key = {{ server.storage.swift.store.key }}
 {% endif %}
 


### PR DESCRIPTION
These changes should patch an issue observed in Ocata when Swift
is set as Glance backend with *references* method of auth sections
addressing. While `glance-api.conf` template is set to check for
swift auth parameters definition, `glance-glare.conf` is not which
makes **salt-formula-glance** fail in execution.