### PR TITLE
Make glance username and group name configurable

### DIFF
--- a/glance/map.jinja
+++ b/glance/map.jinja
@@ -15,6 +15,8 @@
         'audit': {
           'enabled': false
         },
+	'glance_username': 'glance',
+	'glance_groupname': 'glance',
         'glance_uid': 302,
         'glance_gid': 302,
         'amqp': {
@@ -56,6 +58,8 @@
         'audit': {
           'enabled': false
         },
+	'glance_username': 'glance',
+	'glance_groupname': 'glance',
         'glance_uid': 302,
         'glance_gid': 302,
         'amqp': {

--- a/glance/server.sls
+++ b/glance/server.sls
@@ -18,7 +18,7 @@ glance_packages:
 {%- if not salt['user.info']('glance') %}
 glance_user:
   user.present:
-    - name: glance
+    - name: {{ server.get('glance_username') }}
     - home: /var/lib/glance
     {# note: glance uid/gid values would not be evaluated after user is created. #}
     - uid: {{ server.get('glance_uid') }}
@@ -30,7 +30,7 @@ glance_user:
 
 glance_group:
   group.present:
-    - name: glance
+    - name: {{ server.get('glance_groupname') }}
     {# note: glance uid/gid values would not be evaluated after user is created. #}
     - gid: {{ server.get('glance_gid') }}
     - system: True


### PR DESCRIPTION
A small enhancement to make the glance username and group name configurable; on our system the LDAP database already had a glance group (for a completely different purpose). It should generally not
be relied on that a particular group name can be owned by the software.
